### PR TITLE
Tried automatically synchronize MD files to Blogs and Latest Updates pages

### DIFF
--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -1,0 +1,60 @@
+name: Generate docs manifest
+
+on:
+  push:
+    paths:
+      - 'docs/meetings/**/*.md'
+      - 'docs/LearningJournal/**/*.md'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate manifest.json
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          function collect(dir) {
+            if (!fs.existsSync(dir)) return [];
+            return fs.readdirSync(dir)
+              .filter(f => f.endsWith('.md'))
+              .map(name => ({
+                name,
+                path: `${dir}/${name}`.replace(/\\/g, '/')
+              }));
+          }
+
+          const manifest = {
+            meetings: collect('docs/meetings'),
+            learningJournal: collect('docs/LearningJournal'),
+          };
+
+          fs.writeFileSync('docs/manifest.json', JSON.stringify(manifest, null, 2));
+          console.log('Generated docs/manifest.json');
+          NODE
+
+      - name: Commit & push changes
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git add docs/manifest.json
+            git commit -m 'chore: update docs/manifest.json'
+            git push
+          else
+            echo "No changes to commit."
+          fi

--- a/.github/workflows/generate-manifest.yml
+++ b/.github/workflows/generate-manifest.yml
@@ -1,4 +1,6 @@
 name: Generate docs manifest
+permissions:
+  contents: write
 
 on:
   push:

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,26 @@
+{
+  "meetings": [
+    {
+      "name": "2025-05-14-kickoff.md",
+      "path": "docs/meetings/2025-05-14-kickoff.md"
+    },
+    {
+      "name": "2025-05-16-officehour-john-mcnamara.md",
+      "path": "docs/meetings/2025-05-16-officehour-john-mcnamara.md"
+    },
+    {
+      "name": "2025-06-02-MSc-project-workshop.md",
+      "path": "docs/meetings/2025-06-02-MSc-project-workshop.md"
+    },
+    {
+      "name": "2025-06-06-SecondMeeting.md",
+      "path": "docs/meetings/2025-06-06-SecondMeeting.md"
+    }
+  ],
+  "learningJournal": [
+    {
+      "name": "WeihaoZeng.md",
+      "path": "docs/LearningJournal/WeihaoZeng.md"
+    }
+  ]
+}


### PR DESCRIPTION
This update introduces an initial attempt to programmatically link and display .md files (meeting notes, blog entries) on both the “Blogs” and “Latest Updates” sections of the project homepage.
The goal is to reduce manual duplication and ensure up-to-date information is reflected on the site. Further optimisation and formatting improvements may follow in later iterations.